### PR TITLE
Revert #25

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,5 +22,7 @@ deployment:
   production:
     branch: master
     commands:
+      - git config --global user.email "deploy-bot@coderdojonavan.ie"
+      - git config --global user.name "CoderDojoNavan DeployBot"
       - echo "new.coderdojonavan.ie" >> static/CNAME
       - scripts/pages-deploy.sh


### PR DESCRIPTION
This reverts commit 7b8f7d04711513df7bb0c4ae6d7b53b7e3b476f6.

Since CircleCI does not have default git user, the script fails as it makes the presumption at the beginning.